### PR TITLE
Add label to input for accessibility

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,12 @@
         </section>
         <section>
           <div>
-            <input type="text" name="bsn-number" id="bsn-number" />
+            <input
+              type="text"
+              name="bsn-number"
+              id="bsn-number"
+              aria-label="bsn-number"
+            />
             <button id="bsn-number__copy-button" type="button">
               <i class="fa fa-copy" id="bsn-number__copy-icon"></i>
             </button>


### PR DESCRIPTION
The lighthouse report showed there was a label missing for the input.
Added that.

WAS
<img width="566" alt="image" src="https://github.com/willemverbuyst/bsn-tool/assets/91901507/bd183854-8dee-43bb-8270-03a42618c078">

IS
<img width="612" alt="image" src="https://github.com/willemverbuyst/bsn-tool/assets/91901507/0dff8510-8d9b-4d96-be92-e0af69d55e93">
