### PR TITLE
Add robots.txt to dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "source": "src/index.html",
   "type": "module",
   "scripts": {
-    "build": "parcel build src/index.html --public-url ./",
+    "build": "parcel build src/index.html --public-url ./ && cp robots.txt dist/robots.txt",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "format:check": "prettier --config .prettierrc --check \"src/*.*\"",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: 


### PR DESCRIPTION
Added a `robots.txt` and updated the build script.
On build the `robots.txt` is copied over to the dist folder.